### PR TITLE
fix file preview not working non non-Mac OSes

### DIFF
--- a/functions/__fzf_preview_file.fish
+++ b/functions/__fzf_preview_file.fish
@@ -24,6 +24,9 @@ function __fzf_preview_file --description "Prints a preview for the given file b
             set target_path (realpath $file_path)
             set_color yellow; and echo "'$file_path' is a symlink to '$target_path'"
             __fzf_preview_file "$target_path"
+        case "" # occurs when ls failes, e.g. with bad file descriptors
+            set_color red; and echo 'ls filed to get the file type..' >&2
+            exit 1
         case "*"
             echo "Unexpected file symbol $file_symbol. Please open an issue at https://github.com/patrickf3139/fzf.fish."
     end

--- a/functions/__fzf_preview_file.fish
+++ b/functions/__fzf_preview_file.fish
@@ -6,15 +6,15 @@ function __fzf_preview_file --description "Prints a preview for the given file b
     # See https://linuxconfig.org/identifying-file-types-in-linux
     set file_symbol (ls -o -d "$file_path" | string sub --length 1)
     switch $file_symbol
-        case b c
+        case b c # block and character device file
             __fzf_report_file_type "$file_path" "device file"
         case d
             # Setting CLICOLOR_FORCE forces colors to be enabled even to a non-terminal output
             CLICOLOR_FORCE=true ls -a "$file_path"
         case s
             __fzf_report_file_type "$file_path" "socket"
-        case p
-            __fzf_report_file_type "$file_path" "???"
+        case p # named pipe
+            __fzf_report_file_type "$file_path" TODO
         case - l # TODO: test l for directories
             bat --style=numbers --color=always "$file_path"
         case "*"

--- a/functions/__fzf_preview_file.fish
+++ b/functions/__fzf_preview_file.fish
@@ -16,7 +16,11 @@ function __fzf_preview_file --description "Prints a preview for the given file b
         case l # symlink
             # notify user and recurse on the target of the symlink, which can be any of these file types
             set target_path (realpath $file_path)
-            set_color yellow; and echo "'$file_path' is a symlink to '$target_path'."
+
+            set_color yellow
+            echo "'$file_path' is a symlink to '$target_path'."
+            set_color normal
+
             __fzf_preview_file "$target_path"
         case c
             __fzf_report_file_type "$file_path" "character device file"
@@ -27,9 +31,11 @@ function __fzf_preview_file --description "Prints a preview for the given file b
         case p
             __fzf_report_file_type "$file_path" "named pipe"
         case "" # occurs when ls fails, e.g. with bad file descriptors
-            set_color red; and echo 'ls command failed.' >&2
+            set_color red
+            echo 'ls command failed.' >&2
+            set_color normal
             exit 1
         case "*"
-            echo "Unexpected file symbol $file_symbol. Please open an issue at https://github.com/patrickf3139/fzf.fish."
+            echo "Unexpected file symbol $file_symbol. Please open an issue at https://github.com/patrickf3139/fzf.fish." >&2
     end
 end

--- a/functions/__fzf_preview_file.fish
+++ b/functions/__fzf_preview_file.fish
@@ -18,8 +18,10 @@ function __fzf_preview_file --description "Prints a preview for the given file b
             set target_path (realpath $file_path)
             set_color yellow; and echo "'$file_path' is a symlink to '$target_path'."
             __fzf_preview_file "$target_path"
-        case b c # block and character device file
-            __fzf_report_file_type "$file_path" "device file"
+        case c
+            __fzf_report_file_type "$file_path" "character device file"
+        case b
+            __fzf_report_file_type "$file_path" "block device file"
         case s
             __fzf_report_file_type "$file_path" "socket"
         case p

--- a/functions/__fzf_preview_file.fish
+++ b/functions/__fzf_preview_file.fish
@@ -13,17 +13,17 @@ function __fzf_preview_file --description "Prints a preview for the given file b
         case d # directory
             # Setting CLICOLOR_FORCE forces colors to be enabled even to a non-terminal output
             CLICOLOR_FORCE=true ls -a "$file_path"
+        case l # symlink
+            # notify user and recurse on the target of the symlink, which can be any of these file types
+            set target_path (realpath $file_path)
+            set_color yellow; and echo "'$file_path' is a symlink to '$target_path'"
+            __fzf_preview_file "$target_path"
         case b c # block and character device file
             __fzf_report_file_type "$file_path" "device file"
         case s
             __fzf_report_file_type "$file_path" "socket"
         case p
             __fzf_report_file_type "$file_path" "named pipe"
-        case l # symlink
-            # notify user and recurse on the target of the symlink, which can be any of these file types
-            set target_path (realpath $file_path)
-            set_color yellow; and echo "'$file_path' is a symlink to '$target_path'"
-            __fzf_preview_file "$target_path"
         case "" # occurs when ls failes, e.g. with bad file descriptors
             set_color red; and echo 'ls filed to get the file type..' >&2
             exit 1

--- a/functions/__fzf_preview_file.fish
+++ b/functions/__fzf_preview_file.fish
@@ -25,7 +25,7 @@ function __fzf_preview_file --description "Prints a preview for the given file b
         case p
             __fzf_report_file_type "$file_path" "named pipe"
         case "" # occurs when ls fails, e.g. with bad file descriptors
-            set_color red; and echo 'ls failed to get the file type.' >&2
+            set_color red; and echo 'ls command failed.' >&2
             exit 1
         case "*"
             echo "Unexpected file symbol $file_symbol. Please open an issue at https://github.com/patrickf3139/fzf.fish."

--- a/functions/__fzf_preview_file.fish
+++ b/functions/__fzf_preview_file.fish
@@ -1,22 +1,29 @@
 # helper function for __fzf_search_current_dir
 function __fzf_preview_file --description "Prints a preview for the given file based on its file type." --argument-names file_path
-    # -o gives long format without group id
     # -d does not display the contents of named directories, but information about the directories themselves
+    # -o gives long format without group id
     # We want long format because it outputs the file type symbol as the very first character of each row
-    # See https://linuxconfig.org/identifying-file-types-in-linux
     set file_symbol (ls -o -d "$file_path" | string sub --length 1)
+
+    # For more on file symbols outputted by ls long format, see https://linuxconfig.org/identifying-file-types-in-linux
+    # For more on file types, see https://en.wikipedia.org/wiki/Unix_file_types
     switch $file_symbol
         case b c # block and character device file
             __fzf_report_file_type "$file_path" "device file"
         case d
             # Setting CLICOLOR_FORCE forces colors to be enabled even to a non-terminal output
             CLICOLOR_FORCE=true ls -a "$file_path"
-        case s
+        case s # example socket: /tmp/.s.PGSQL.5432
             __fzf_report_file_type "$file_path" "socket"
-        case p # named pipe
-            __fzf_report_file_type "$file_path" TODO
-        case - l # TODO: test l for directories
+        case p
+            __fzf_report_file_type "$file_path" "named pipe"
+        case -
             bat --style=numbers --color=always "$file_path"
+        case l
+            # handle symlinks by notifying user and recursing on the target of the symlink
+            set target_path (realpath $file_path)
+            set_color yellow; and echo "'$file_path' is a symlink to '$target_path'"
+            __fzf_preview_file "$target_path"
         case "*"
             echo "Unsure how to preview '$file_path', which has file symbol $file_symbol. Please open an issue at https://github.com/patrickf3139/fzf.fish."
     end

--- a/functions/__fzf_preview_file.fish
+++ b/functions/__fzf_preview_file.fish
@@ -13,14 +13,14 @@ function __fzf_preview_file --description "Prints a preview for the given file b
         case d
             # Setting CLICOLOR_FORCE forces colors to be enabled even to a non-terminal output
             CLICOLOR_FORCE=true ls -a "$file_path"
-        case s # example socket: /tmp/.s.PGSQL.5432
+        case s
             __fzf_report_file_type "$file_path" "socket"
         case p
             __fzf_report_file_type "$file_path" "named pipe"
         case -
             bat --style=numbers --color=always "$file_path"
         case l
-            # handle symlinks by notifying user and recursing on the target of the symlink
+            # handle symlinks by notifying user and recursing on the target of the symlink as it could be any of these file types
             set target_path (realpath $file_path)
             set_color yellow; and echo "'$file_path' is a symlink to '$target_path'"
             __fzf_preview_file "$target_path"

--- a/functions/__fzf_preview_file.fish
+++ b/functions/__fzf_preview_file.fish
@@ -8,23 +8,23 @@ function __fzf_preview_file --description "Prints a preview for the given file b
     # For more on file symbols outputted by ls long format, see https://linuxconfig.org/identifying-file-types-in-linux
     # For more on file types, see https://en.wikipedia.org/wiki/Unix_file_types
     switch $file_symbol
-        case b c # block and character device file
-            __fzf_report_file_type "$file_path" "device file"
-        case d
+        case - # regular file
+            bat --style=numbers --color=always "$file_path"
+        case d # directory
             # Setting CLICOLOR_FORCE forces colors to be enabled even to a non-terminal output
             CLICOLOR_FORCE=true ls -a "$file_path"
+        case b c # block and character device file
+            __fzf_report_file_type "$file_path" "device file"
         case s
             __fzf_report_file_type "$file_path" "socket"
         case p
             __fzf_report_file_type "$file_path" "named pipe"
-        case -
-            bat --style=numbers --color=always "$file_path"
-        case l
-            # handle symlinks by notifying user and recursing on the target of the symlink as it could be any of these file types
+        case l # symlink
+            # notify user and recurse on the target of the symlink, which can be any of these file types
             set target_path (realpath $file_path)
             set_color yellow; and echo "'$file_path' is a symlink to '$target_path'"
             __fzf_preview_file "$target_path"
         case "*"
-            echo "Unsure how to preview '$file_path', which has file symbol $file_symbol. Please open an issue at https://github.com/patrickf3139/fzf.fish."
+            echo "Unexpected file symbol $file_symbol. Please open an issue at https://github.com/patrickf3139/fzf.fish."
     end
 end

--- a/functions/__fzf_preview_file.fish
+++ b/functions/__fzf_preview_file.fish
@@ -1,19 +1,23 @@
 # helper function for __fzf_search_current_dir
 function __fzf_preview_file --description "Prints a preview for the given file based on its file type." --argument-names file_path
-    set file_type (file --brief -i "$file_path")
-    switch $file_type
-        case "directory"
+    # -o gives long format without group id
+    # -d does not display the contents of named directories, but information about the directories themselves
+    # We want long format because it outputs the file type symbol as the very first character of each row
+    # See https://linuxconfig.org/identifying-file-types-in-linux
+    set file_symbol (ls -o -d "$file_path" | string sub --length 1)
+    switch $file_symbol
+        case b c
+            __fzf_report_file_type "$file_path" "device file"
+        case d
             # Setting CLICOLOR_FORCE forces colors to be enabled even to a non-terminal output
             CLICOLOR_FORCE=true ls -a "$file_path"
-        case "socket"
+        case s
             __fzf_report_file_type "$file_path" "socket"
-        case "broken symbolic link*" # example: "broken symbolic link to /path/to/file""
-            __fzf_report_file_type "$file_path" "broken symbolic link"
-        case "* special *" # examples: "character special (23/5)" and "block special (1/7)"
-            __fzf_report_file_type "$file_path" "device file"
-        case "regular file"
+        case p
+            __fzf_report_file_type "$file_path" "???"
+        case - l # TODO: test l for directories
             bat --style=numbers --color=always "$file_path"
         case "*"
-            echo "Unsure how to preview '$file_path', which has file type '$file_type'. Please open an issue at https://github.com/patrickf3139/fzf.fish."
+            echo "Unsure how to preview '$file_path', which has file symbol $file_symbol. Please open an issue at https://github.com/patrickf3139/fzf.fish."
     end
 end

--- a/functions/__fzf_preview_file.fish
+++ b/functions/__fzf_preview_file.fish
@@ -16,7 +16,7 @@ function __fzf_preview_file --description "Prints a preview for the given file b
         case l # symlink
             # notify user and recurse on the target of the symlink, which can be any of these file types
             set target_path (realpath $file_path)
-            set_color yellow; and echo "'$file_path' is a symlink to '$target_path'"
+            set_color yellow; and echo "'$file_path' is a symlink to '$target_path'."
             __fzf_preview_file "$target_path"
         case b c # block and character device file
             __fzf_report_file_type "$file_path" "device file"
@@ -24,8 +24,8 @@ function __fzf_preview_file --description "Prints a preview for the given file b
             __fzf_report_file_type "$file_path" "socket"
         case p
             __fzf_report_file_type "$file_path" "named pipe"
-        case "" # occurs when ls failes, e.g. with bad file descriptors
-            set_color red; and echo 'ls filed to get the file type..' >&2
+        case "" # occurs when ls fails, e.g. with bad file descriptors
+            set_color red; and echo 'ls failed to get the file type.' >&2
             exit 1
         case "*"
             echo "Unexpected file symbol $file_symbol. Please open an issue at https://github.com/patrickf3139/fzf.fish."

--- a/functions/__fzf_preview_file.fish
+++ b/functions/__fzf_preview_file.fish
@@ -1,7 +1,7 @@
 # helper function for __fzf_search_current_dir
 function __fzf_preview_file --description "Prints a preview for the given file based on its file type." --argument-names file_path
-    # -d does not display the contents of named directories, but information about the directories themselves
-    # -o gives long format without group id
+    # -d displays information about the directories themselves instead of the contents of the directories
+    # -o displays long format without group id
     # We want long format because it outputs the file type symbol as the very first character of each row
     set file_symbol (ls -o -d "$file_path" | string sub --length 1)
 

--- a/functions/__fzf_report_file_type.fish
+++ b/functions/__fzf_report_file_type.fish
@@ -1,6 +1,6 @@
 # helper function for __fzf_preview_file
 function __fzf_report_file_type --description "Explain the file type for a file." --argument-names file_path file_type
     set_color red
-    echo "Cannot preview: '$file_path' is a $file_type."
+    echo "Cannot preview '$file_path': it is a $file_type."
     set_color normal
 end


### PR DESCRIPTION
# Problem
File preview wasn't working on Linux and presumably Windows because the `file` command that ships with Mac, used to determine the file type, is outdated and has different options. See #19

# Solution
Use `ls` to get the file type instead. Big thanks to @chshbh for the idea of using `ls`! He opened up a great PR in #20 