### PR TITLE
Use test builtin to get file type

### DIFF
--- a/functions/__fzf_preview_file.fish
+++ b/functions/__fzf_preview_file.fish
@@ -1,41 +1,28 @@
 # helper function for __fzf_search_current_dir
 function __fzf_preview_file --description "Prints a preview for the given file based on its file type." --argument-names file_path
-    # -d displays information about the directories themselves instead of the contents of the directories
-    # -o displays long format without group id. We want long format because it gives the file type as the very first character
-    # Executing ls with command because users may have ls aliased to exa
-    set file_type_char (command ls -o -d "$file_path" | string sub --length 1)
+    if test -f "$file_path" # regular file
+        bat --style=numbers --color=always "$file_path"
+    else if test -d "$file_path" # directory
+        set --local CLICOLOR_FORCE true
+        ls -a "$file_path"
+    else if test -L "$file_path" # symlink
+        # notify user and recurse on the target of the symlink, which can be any of these file types
+        set -l target_path (realpath $file_path)
 
-    # For more on file symbols outputted by ls long format, see https://linuxconfig.org/identifying-file-types-in-linux
-    # For more on file types, see https://en.wikipedia.org/wiki/Unix_file_types
-    switch $file_type_char
-        case - # regular file
-            bat --style=numbers --color=always "$file_path"
-        case d # directory
-            # Setting CLICOLOR_FORCE forces colors to be enabled even to a non-terminal output
-            CLICOLOR_FORCE=true ls -a "$file_path"
-        case l # symlink
-            # notify user and recurse on the target of the symlink, which can be any of these file types
-            set target_path (realpath $file_path)
+        set_color yellow
+        echo "'$file_path' is a symlink to '$target_path'."
+        set_color normal
 
-            set_color yellow
-            echo "'$file_path' is a symlink to '$target_path'."
-            set_color normal
-
-            __fzf_preview_file "$target_path"
-        case c
-            __fzf_report_file_type "$file_path" "character device file"
-        case b
-            __fzf_report_file_type "$file_path" "block device file"
-        case s
-            __fzf_report_file_type "$file_path" "socket"
-        case p
-            __fzf_report_file_type "$file_path" "named pipe"
-        case "" # occurs when ls fails, e.g. with bad file descriptors
-            set_color red
-            echo 'ls command failed.' >&2
-            set_color normal
-            exit 1
-        case "*"
-            echo "Unexpected file symbol $file_type_char. Please open an issue at https://github.com/patrickf3139/fzf.fish." >&2
+        __fzf_preview_file "$target_path"
+    else if test -c "$file_path"
+        __fzf_report_file_type "$file_path" "character device file"
+    else if test -b "$file_path"
+        __fzf_report_file_type "$file_path" "block device file"
+    else if test -S "$file_path"
+        __fzf_report_file_type "$file_path" "socket"
+    else if test -p "$file_path"
+        __fzf_report_file_type "$file_path" "named pipe"
+    else
+        echo "Unexpected file symbol $file_type_char. Please open an issue at https://github.com/patrickf3139/fzf.fish." >&2
     end
 end


### PR DESCRIPTION
Use the builtin `test` repeatedly instead `command ls -o -d "$file_path" | string sub --length 1`. Running `test`, though having to do it multiple times, is much faster and less hacky. I have tested this by creating a named pipe with `mknod named-pipe-identifier p` and then spamming time `_fzf_preview_file named-pipe-identifier`. 200 microseconds vs. 3ms on my arch vm.