### PR TITLE
Format readme with prettier, use reference links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
-<h1 align="center">
-    fzf.fish
-</h1>
+<div align="center">
 
-A plugin that integrates [fzf](https://github.com/junegunn/fzf) into your [fish](http://fishshell.com) workflow. Comes with handy functions&mdash;each with its own mnemonic key binding&mdash;that use fzf to
+# fzf.fish
+
+</div>
+
+A plugin that integrates [fzf](https://github.com/junegunn/fzf) into your [fish](http://fishshell.com) workflow. Comes with handy functions—each with its own mnemonic key binding—that use fzf to
 
 > Search and preview files under the **current directory** - `Ctrl+f` (f for file)
 
@@ -25,59 +27,78 @@ A plugin that integrates [fzf](https://github.com/junegunn/fzf) into your [fish]
 ![shell variables search](/images/shell_variables.png)
 
 ## Installation
+
 First, make sure you are running fish `3.1.2`.
-```sh
+
+```fish
 > fish --version
 fish, version 3.1.2
 ```
 
 Next, install this plugin with a package manager.
+
 - With [fisher](https://github.com/jorgebucaran/fisher)
-    ```fish
-    fisher add patrickf3139/fzf.fish
-    ```
+
+  ```fish
+  fisher add patrickf3139/fzf.fish
+  ```
+
 - Or with [Oh My Fish](https://github.com/oh-my-fish/oh-my-fish)
-    ```fish
-    omf install https://github.com/patrickf3139/fzf.fish
-    ```
+
+  ```fish
+  omf install https://github.com/patrickf3139/fzf.fish
+  ```
 
 Finally, install the following CLI tools:
+
 - [fzf](https://github.com/junegunn/fzf), the command-line fuzzy finder that powers this plugin;
 - [fd](https://github.com/sharkdp/fd), a much faster and friendlier alternative to the antiquated `find` command (used for the file search feature); and
 - [bat](https://github.com/sharkdp/bat), a smarter `cat` with syntax highlighting (used to preview files).
 
-If you are on Mac, I recommend installing them using [brew](https://brew.sh/). <br>
+If you are on Mac, I recommend installing them using [brew](https://brew.sh/).
+
 If you are on Ubuntu, you will need to alias `fdfind` to `fd` (see [#23](https://github.com/patrickf3139/fzf.fish/issues/23)).
 
 ## Configuration
+
 ### Using custom key bindings
+
 Each function is assigned mnemonic key bindings by default (see screenshots above) in [conf.d/fzf.fish](conf.d/fzf.fish). However, if you would like to customize them, you can prevent the default key bindings from executing by setting `fzf_fish_custom_keybindings` as a [universal variable](https://fishshell.com/docs/current/#more-on-universal-variables). You can do this by running
+
 ```fish
 set --universal fzf_fish_custom_keybindings
 ```
+
 Do not try to set `fzf_fish_custom_keybindings` in your `config.fish` because `conf.d/fzf.fish` is sourced first on shell startup and so will not see it. Once it is set, you can set up your own key bindings.
 
-### Fzf default options
+### Fzf default options <br>
+
 fzf supports setting default options via the [FZF_DEFAULT_OPTS](https://github.com/junegunn/fzf#environment-variables) environment variable. If it is set, fzf will implicitly prepend its value to the options passed in on every execution, scripted or interactive.
 
 To make fzf's interface friendlier, `fzf.fish` takes the liberty of setting a sane `FZF_DEFAULT_OPTS` if it is not already set. See [conf.d/fzf.fish](conf.d/fzf.fish) for more details. This affects fzf even outside of this plugin. If you would like to remove this side effect or just want to customize fzf's default options, then set your own `FZF_DEFAULT_OPTS` universal variable. For example:
+
 ```fish
 set --universal --export FZF_DEFAULT_OPTS --height 50% --margin 1
 ```
+
 Alternatively, you can override it in your `config.fish` by adding in something like this:
+
 ```fish
 set --export FZF_DEFAULT_OPTS --height 50% --margin 1
 ```
 
 ## Prior art
-### jethrokuan/fzf
-[jethrokuan/fzf](https://github.com/jethrokuan/fzf) is another fzf plugin that provides similar features and is prevalent in the fish community (470+ stargazers and 30 contributors, including me). In fact, I borrowed from it some ideas when creating this plugin&mdash;thank you Jethro!
 
-So why *another* fzf plugin? While contributing to `jethrokuan/fzf`, I was discouraged by the complexity and inefficiency of the code that resulted from feature cruft (e.g. it provides multiple ways to action on files (find, cd, and open) rather than relying on the user to action the files themselves using the command line) and poor design decisions (e.g. the Tmux support, implemented using a variable command, would have been better done using an alias). Moreover, Jethro seemed to have lost interest in his plugin (he later confirmed to me that he stopped using fish). Wanting a sharper tool and to give back to the community, I decided to write my own plugin.
+### jethrokuan/fzf
+
+[jethrokuan/fzf](https://github.com/jethrokuan/fzf) is another fzf plugin that provides similar features and is prevalent in the fish community (470+ stargazers and 30 contributors, including me). In fact, I borrowed from it some ideas when creating this plugin—thank you Jethro!
+
+So why _another_ fzf plugin? While contributing to `jethrokuan/fzf`, I was discouraged by the complexity and inefficiency of the code that resulted from feature cruft (e.g. it provides multiple ways to action on files (find, cd, and open) rather than relying on the user to action the files themselves using the command line) and poor design decisions (e.g. the Tmux support, implemented using a variable command, would have been better done using an alias). Moreover, Jethro seemed to have lost interest in his plugin (he later confirmed to me that he stopped using fish). Wanting a sharper tool and to give back to the community, I decided to write my own plugin.
 
 After much work, `fzf.fish` now implements most of the same features but is faster, easier to maintain, and more [Unix-y](https://en.wikipedia.org/wiki/Unix_philosophy). I also added new features: using fzf to search git status, git log, and shell variables. However, I chose not to implement Tmux support, because users can easily add support externally themselves; and tab completion, because even `jethrokuan/fzf`'s implementation of it is buggy and difficult to maintain as evidenced by the many [issues reported about it](https://github.com/jethrokuan/fzf/issues?q=is%3Aissue+tab).
 
 **TLDR:** choose `fzf.fish` over [jethrokuan/fzf](https://github.com/jethrokuan/fzf) if you want
+
 - more efficient, faster code
 - to run code that is easier to debug in case you encounter issues
 - a tool built on [Unix philosophy](https://en.wikipedia.org/wiki/Unix_philosophy)
@@ -86,11 +107,14 @@ After much work, `fzf.fish` now implements most of the same features but is fast
 - functionality for searching git status, git log, and shell variables
 
 and you don't mind
+
 - having to integrate fzf with Tmux yourself, which is easy to do
 - not having buggy fzf tab completion
 
-### Fzf's out-of-the-box fish extension
+### fzf's out-of-the-box fish extension
+
 Fzf optionally comes with its [own fish extension](https://github.com/junegunn/fzf/blob/master/shell/key-bindings.fish). It is substantial but `fzf.fish` has several advantages over it. `fzf.fish`:
+
 - has features for searching git status, git log, and shell variables
 - includes timestamps when searching command history
 - colorizes results when searching for files

--- a/README.md
+++ b/README.md
@@ -4,27 +4,27 @@
 
 </div>
 
-A plugin that integrates [fzf](https://github.com/junegunn/fzf) into your [fish](http://fishshell.com) workflow. Comes with handy functions—each with its own mnemonic key binding—that use fzf to
+A plugin that integrates [fzf][] into your [fish][] workflow. Comes with handy functions—each with its own mnemonic key binding—that use fzf to
 
 > Search and preview files under the **current directory** - `Ctrl+f` (f for file)
 
-![file search](/images/current_dir_files.png)
+![file search][]
 
 > Search the current repository's **git status** - `Ctrl+Alt+s` (s for status, Alt to prevent overriding filter tab completion), `⇥` to multi-select
 
-![git status select](/images/git_status.png)
+![git status select][]
 
 > Search and preview the current repository's **git log** - `Ctrl+Alt+l` (l for log, Alt to prevent overriding clear screen)
 
-![git log](/images/git_log.png)
+![git log][]
 
 > Search **command history** - `Ctrl+r` (r for reverse-i-search)
 
-![command history search](/images/command_history.png)
+![command history search][]
 
 > Search and preview **shell variables** (both local and exported) - `Ctrl+v` (v for variable)
 
-![shell variables search](/images/shell_variables.png)
+![shell variables search][]
 
 ## Installation
 
@@ -37,13 +37,13 @@ fish, version 3.1.2
 
 Next, install this plugin with a package manager.
 
-- With [fisher](https://github.com/jorgebucaran/fisher)
+- With [fisher][]
 
   ```fish
   fisher add patrickf3139/fzf.fish
   ```
 
-- Or with [Oh My Fish](https://github.com/oh-my-fish/oh-my-fish)
+- Or with [Oh My Fish][]
 
   ```fish
   omf install https://github.com/patrickf3139/fzf.fish
@@ -51,19 +51,19 @@ Next, install this plugin with a package manager.
 
 Finally, install the following CLI tools:
 
-- [fzf](https://github.com/junegunn/fzf), the command-line fuzzy finder that powers this plugin;
-- [fd](https://github.com/sharkdp/fd), a much faster and friendlier alternative to the antiquated `find` command (used for the file search feature); and
-- [bat](https://github.com/sharkdp/bat), a smarter `cat` with syntax highlighting (used to preview files).
+- [fzf][], the command-line fuzzy finder that powers this plugin;
+- [fd][], a much faster and friendlier alternative to the antiquated `find` command (used for the file search feature); and
+- [bat][], a smarter `cat` with syntax highlighting (used to preview files).
 
-If you are on Mac, I recommend installing them using [brew](https://brew.sh/).
+If you are on Mac, I recommend installing them using [brew][].
 
-If you are on Ubuntu, you will need to alias `fdfind` to `fd` (see [#23](https://github.com/patrickf3139/fzf.fish/issues/23)).
+If you are on Ubuntu, you will need to alias `fdfind` to `fd` (see [#23][]).
 
 ## Configuration
 
 ### Using custom key bindings
 
-Each function is assigned mnemonic key bindings by default (see screenshots above) in [conf.d/fzf.fish](conf.d/fzf.fish). However, if you would like to customize them, you can prevent the default key bindings from executing by setting `fzf_fish_custom_keybindings` as a [universal variable](https://fishshell.com/docs/current/#more-on-universal-variables). You can do this by running
+Each function is assigned mnemonic key bindings by default (see screenshots above) in [conf.d/fzf.fish][]. However, if you would like to customize them, you can prevent the default key bindings from executing by setting `fzf_fish_custom_keybindings` as a [universal variable][]. You can do this by running
 
 ```fish
 set --universal fzf_fish_custom_keybindings
@@ -71,11 +71,11 @@ set --universal fzf_fish_custom_keybindings
 
 Do not try to set `fzf_fish_custom_keybindings` in your `config.fish` because `conf.d/fzf.fish` is sourced first on shell startup and so will not see it. Once it is set, you can set up your own key bindings.
 
-### Fzf default options <br>
+### Fzf default options
 
-fzf supports setting default options via the [FZF_DEFAULT_OPTS](https://github.com/junegunn/fzf#environment-variables) environment variable. If it is set, fzf will implicitly prepend its value to the options passed in on every execution, scripted or interactive.
+fzf supports setting default options via the [FZF_DEFAULT_OPTS][] environment variable. If it is set, fzf will implicitly prepend its value to the options passed in on every execution, scripted or interactive.
 
-To make fzf's interface friendlier, `fzf.fish` takes the liberty of setting a sane `FZF_DEFAULT_OPTS` if it is not already set. See [conf.d/fzf.fish](conf.d/fzf.fish) for more details. This affects fzf even outside of this plugin. If you would like to remove this side effect or just want to customize fzf's default options, then set your own `FZF_DEFAULT_OPTS` universal variable. For example:
+To make fzf's interface friendlier, `fzf.fish` takes the liberty of setting a sane `FZF_DEFAULT_OPTS` if it is not already set. See [conf.d/fzf.fish][] for more details. This affects fzf even outside of this plugin. If you would like to remove this side effect or just want to customize fzf's default options, then set your own `FZF_DEFAULT_OPTS` universal variable. For example:
 
 ```fish
 set --universal --export FZF_DEFAULT_OPTS --height 50% --margin 1
@@ -91,17 +91,17 @@ set --export FZF_DEFAULT_OPTS --height 50% --margin 1
 
 ### jethrokuan/fzf
 
-[jethrokuan/fzf](https://github.com/jethrokuan/fzf) is another fzf plugin that provides similar features and is prevalent in the fish community (470+ stargazers and 30 contributors, including me). In fact, I borrowed from it some ideas when creating this plugin—thank you Jethro!
+[jethrokuan/fzf][] is another fzf plugin that provides similar features and is prevalent in the fish community (470+ stargazers and 30 contributors, including me). In fact, I borrowed from it some ideas when creating this plugin—thank you Jethro!
 
 So why _another_ fzf plugin? While contributing to `jethrokuan/fzf`, I was discouraged by the complexity and inefficiency of the code that resulted from feature cruft (e.g. it provides multiple ways to action on files (find, cd, and open) rather than relying on the user to action the files themselves using the command line) and poor design decisions (e.g. the Tmux support, implemented using a variable command, would have been better done using an alias). Moreover, Jethro seemed to have lost interest in his plugin (he later confirmed to me that he stopped using fish). Wanting a sharper tool and to give back to the community, I decided to write my own plugin.
 
-After much work, `fzf.fish` now implements most of the same features but is faster, easier to maintain, and more [Unix-y](https://en.wikipedia.org/wiki/Unix_philosophy). I also added new features: using fzf to search git status, git log, and shell variables. However, I chose not to implement Tmux support, because users can easily add support externally themselves; and tab completion, because even `jethrokuan/fzf`'s implementation of it is buggy and difficult to maintain as evidenced by the many [issues reported about it](https://github.com/jethrokuan/fzf/issues?q=is%3Aissue+tab).
+After much work, `fzf.fish` now implements most of the same features but is faster, easier to maintain, and more [Unix-y][unix philosophy]. I also added new features: using fzf to search git status, git log, and shell variables. However, I chose not to implement Tmux support, because users can easily add support externally themselves; and tab completion, because even `jethrokuan/fzf`'s implementation of it is buggy and difficult to maintain as evidenced by the many [issues reported about it][].
 
-**TLDR:** choose `fzf.fish` over [jethrokuan/fzf](https://github.com/jethrokuan/fzf) if you want
+**TLDR:** choose `fzf.fish` over [jethrokuan/fzf][] if you want
 
-- more efficient, faster code
-- to run code that is easier to debug in case you encounter issues
-- a tool built on [Unix philosophy](https://en.wikipedia.org/wiki/Unix_philosophy)
+- faster, more efficient, code
+- code that is easier to debug if you encounter issues
+- a tool built on [Unix philosophy][]
 - a plugin that is more likely to attract future contributors because it is more maintainable
 - a plugin that will be more frequently updated by its author (Jethro no longer uses fish)
 - functionality for searching git status, git log, and shell variables
@@ -113,13 +113,35 @@ and you don't mind
 
 ### fzf's out-of-the-box fish extension
 
-Fzf optionally comes with its [own fish extension](https://github.com/junegunn/fzf/blob/master/shell/key-bindings.fish). It is substantial but `fzf.fish` has several advantages over it. `fzf.fish`:
+Fzf optionally comes with its [own fish extension][]. It is substantial but `fzf.fish` has several advantages over it. `fzf.fish`:
 
 - has features for searching git status, git log, and shell variables
 - includes timestamps when searching command history
 - colorizes results when searching for files
 - shows previews when searching for files
 - has configurable key bindings
-- [autoloads](https://fishshell.com/docs/current/tutorial.html#autoloading-functions) its functions for faster shell startup
+- [autoloads][] its functions for faster shell startup
 - is easier to read, maintain, and contribute to
 - will likely be more frequently updated
+
+[#23]: https://github.com/patrickf3139/fzf.fish/issues/23
+[autoloads]: https://fishshell.com/docs/current/tutorial.html#autoloading-functions
+[bat]: https://github.com/sharkdp/bat
+[brew]: https://brew.sh/
+[command history search]: images/command_history.png
+[conf.d/fzf.fish]: conf.d/fzf.fish
+[fd]: https://github.com/sharkdp/fd
+[file search]: images/current_dir_files.png
+[fish]: http://fishshell.com
+[fisher]: https://github.com/jorgebucaran/fisher
+[fzf_default_opts]: https://github.com/junegunn/fzf#environment-variables
+[fzf]: https://github.com/junegunn/fzf
+[git log]: images/git_log.png
+[git status select]: images/git_status.png
+[issues reported about it]: https://github.com/jethrokuan/fzf/issues?q=is%3Aissue+tab
+[jethrokuan/fzf]: https://github.com/jethrokuan/fzf
+[oh my fish]: https://github.com/oh-my-fish/oh-my-fish
+[own fish extension]: https://github.com/junegunn/fzf/blob/master/shell/key-bindings.fish
+[shell variables search]: images/shell_variables.png
+[universal variable]: https://fishshell.com/docs/current/#more-on-universal-variables
+[unix philosophy]: https://en.wikipedia.org/wiki/Unix_philosophy


### PR DESCRIPTION
1. Use prettier to format the README. Ensures consistent style, spacing, etc.
2. Reduce HTML use.
3. Use — (actual emdash character) instead of `&mdash;`.

Broken out from #30.