### PR TITLE
Convert license to markdown

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
-MIT License
+# MIT License
 
-Copyright (c) 2020 Patrick
+Copyright © `2020` `Patrick`
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Convert license to markdown. As with README, CONTRIBUTING, CHANGELOG and the rest of the family, LICENSE is meant to be read by humans (granted no one ever actually reads the MIT license because we all know what it says, but still). Anything that is meant to be read by humans should be rendered by the browser into good looking HTML, not displayed as plain text.