### PR TITLE
Prevent double invocation of git

### DIFF
--- a/functions/__fzf_search_git_log.fish
+++ b/functions/__fzf_search_git_log.fish
@@ -1,14 +1,11 @@
 # Originally implemented in and transposed from https://github.com/patrickf3139/dotfiles/pull/2
 function __fzf_search_git_log --description "Search the git log of the current git repository. Insert the selected commit hash into the commandline at the cursor."
-    if not git rev-parse --git-dir >/dev/null 2>&1
+    # see documentation for git format placeholders at https://git-scm.com/docs/git-log#Documentation/git-log.txt-emnem
+    # %h gives you the abbreviated commit hash, which is useful for saving screen space, but we will have to expand it later below
+    if not set --local git_log (git log --color=always --format=format:'%C(bold blue)%h%C(reset) - %C(cyan)%as%C(reset) %C(yellow)%d%C(reset) %C(normal)%s%C(reset)  %C(dim normal)[%an]%C(reset)' 2>/dev/null)
         echo '__fzf_search_git_log: Not in a git repository.' >&2
     else
-        set selected_log_line (
-            # see documentation for git format placeholders at https://git-scm.com/docs/git-log#Documentation/git-log.txt-emnem
-            # %h gives you the abbreviated commit hash, which is useful for saving screen space, but we will have to expand it later below
-            git log --color=always --format=format:'%C(bold blue)%h%C(reset) - %C(cyan)%as%C(reset) %C(yellow)%d%C(reset) %C(normal)%s%C(reset)  %C(dim normal)[%an]%C(reset)' | \
-            fzf --ansi --tiebreak=index --preview='git show --color=always (string split --max 1 " " {})[1]'
-        )
+        set selected_log_line (printf '%s\n' $gitLog | fzf --ansi --tiebreak=index --preview='git show --color=always (string split --max 1 " " {})[1]')
         if test $status -eq 0
             set abbreviated_commit_hash (string split --max 1 " " $selected_log_line)[1]
             set commit_hash (git rev-parse $abbreviated_commit_hash)

--- a/functions/__fzf_search_git_log.fish
+++ b/functions/__fzf_search_git_log.fish
@@ -2,7 +2,8 @@
 function __fzf_search_git_log --description "Search the git log of the current git repository. Insert the selected commit hash into the commandline at the cursor."
     # see documentation for git format placeholders at https://git-scm.com/docs/git-log#Documentation/git-log.txt-emnem
     # %h gives you the abbreviated commit hash, which is useful for saving screen space, but we will have to expand it later below
-    if not set git_log (git log --color=always --format=format:'%C(bold blue)%h%C(reset) - %C(cyan)%as%C(reset) %C(yellow)%d%C(reset) %C(normal)%s%C(reset)  %C(dim normal)[%an]%C(reset)' 2>/dev/null)
+    set git_log (git log --color=always --format=format:'%C(bold blue)%h%C(reset) - %C(cyan)%as%C(reset) %C(yellow)%d%C(reset) %C(normal)%s%C(reset)  %C(dim normal)[%an]%C(reset)' 2>/dev/null)
+    if test $status -ne 0
         echo '__fzf_search_git_log: Not in a git repository.' >&2
     else
         set selected_log_line (printf '%s\n' $git_log | fzf --ansi --tiebreak=index --preview='git show --color=always (string split --max 1 " " {})[1]')

--- a/functions/__fzf_search_git_log.fish
+++ b/functions/__fzf_search_git_log.fish
@@ -2,7 +2,7 @@
 function __fzf_search_git_log --description "Search the git log of the current git repository. Insert the selected commit hash into the commandline at the cursor."
     # see documentation for git format placeholders at https://git-scm.com/docs/git-log#Documentation/git-log.txt-emnem
     # %h gives you the abbreviated commit hash, which is useful for saving screen space, but we will have to expand it later below
-    if not set --local git_log (git log --color=always --format=format:'%C(bold blue)%h%C(reset) - %C(cyan)%as%C(reset) %C(yellow)%d%C(reset) %C(normal)%s%C(reset)  %C(dim normal)[%an]%C(reset)' 2>/dev/null)
+    if not set git_log (git log --color=always --format=format:'%C(bold blue)%h%C(reset) - %C(cyan)%as%C(reset) %C(yellow)%d%C(reset) %C(normal)%s%C(reset)  %C(dim normal)[%an]%C(reset)' 2>/dev/null)
         echo '__fzf_search_git_log: Not in a git repository.' >&2
     else
         set selected_log_line (printf '%s\n' $git_log | fzf --ansi --tiebreak=index --preview='git show --color=always (string split --max 1 " " {})[1]')

--- a/functions/__fzf_search_git_log.fish
+++ b/functions/__fzf_search_git_log.fish
@@ -5,7 +5,7 @@ function __fzf_search_git_log --description "Search the git log of the current g
     if not set --local git_log (git log --color=always --format=format:'%C(bold blue)%h%C(reset) - %C(cyan)%as%C(reset) %C(yellow)%d%C(reset) %C(normal)%s%C(reset)  %C(dim normal)[%an]%C(reset)' 2>/dev/null)
         echo '__fzf_search_git_log: Not in a git repository.' >&2
     else
-        set selected_log_line (printf '%s\n' $gitLog | fzf --ansi --tiebreak=index --preview='git show --color=always (string split --max 1 " " {})[1]')
+        set selected_log_line (printf '%s\n' $git_log | fzf --ansi --tiebreak=index --preview='git show --color=always (string split --max 1 " " {})[1]')
         if test $status -eq 0
             set abbreviated_commit_hash (string split --max 1 " " $selected_log_line)[1]
             set commit_hash (git rev-parse $abbreviated_commit_hash)

--- a/functions/__fzf_search_git_status.fish
+++ b/functions/__fzf_search_git_status.fish
@@ -1,9 +1,9 @@
 function __fzf_search_git_status --description "Search the git status of the current git repository. Insert the selected file paths into the commandline at the cursor."
     # Pass configuration color.status=always to force status to use colors even though output is sent to a pipe
-    if not set --local git_color_status (git -c color.status=always status --short 2>/dev/null)
+    if not set --local git_status_colored (git -c color.status=always status --short 2>/dev/null)
         echo '__fzf_search_git_status: Not in a git repository.' >&2
     else
-        set selected_paths (printf '%s\n' $gitColorStatus | fzf --ansi --multi)
+        set selected_paths (printf '%s\n' $git_status_colored | fzf --ansi --multi)
         if test $status -eq 0
             # git status --short automatically escapes the paths of most files for us so not going to bother trying to handle
             # the few edges cases of weird file names that should be extremely rare (e.g. "this;needs;escaping")

--- a/functions/__fzf_search_git_status.fish
+++ b/functions/__fzf_search_git_status.fish
@@ -1,6 +1,7 @@
 function __fzf_search_git_status --description "Search the git status of the current git repository. Insert the selected file paths into the commandline at the cursor."
     # Pass configuration color.status=always to force status to use colors even though output is sent to a pipe
-    if not set git_status_colored (git -c color.status=always status --short 2>/dev/null)
+    set git_status_colored (git -c color.status=always status --short 2>/dev/null)
+    if test $status -ne 0
         echo '__fzf_search_git_status: Not in a git repository.' >&2
     else
         set selected_paths (printf '%s\n' $git_status_colored | fzf --ansi --multi)

--- a/functions/__fzf_search_git_status.fish
+++ b/functions/__fzf_search_git_status.fish
@@ -1,6 +1,6 @@
 function __fzf_search_git_status --description "Search the git status of the current git repository. Insert the selected file paths into the commandline at the cursor."
     # Pass configuration color.status=always to force status to use colors even though output is sent to a pipe
-    if not set --local git_status_colored (git -c color.status=always status --short 2>/dev/null)
+    if not set git_status_colored (git -c color.status=always status --short 2>/dev/null)
         echo '__fzf_search_git_status: Not in a git repository.' >&2
     else
         set selected_paths (printf '%s\n' $git_status_colored | fzf --ansi --multi)

--- a/functions/__fzf_search_git_status.fish
+++ b/functions/__fzf_search_git_status.fish
@@ -1,12 +1,9 @@
 function __fzf_search_git_status --description "Search the git status of the current git repository. Insert the selected file paths into the commandline at the cursor."
-    if not git rev-parse --git-dir >/dev/null 2>&1
+    # Pass configuration color.status=always to force status to use colors even though output is sent to a pipe
+    if not set --local git_color_status (git -c color.status=always status --short 2>/dev/null)
         echo '__fzf_search_git_status: Not in a git repository.' >&2
     else
-        set selected_paths (
-            # Pass configuration color.status=always to force status to use colors even though output is sent to a pipe
-            git -c color.status=always status --short |
-            fzf --ansi --multi
-        )
+        set selected_paths (printf '%s\n' $gitColorStatus | fzf --ansi --multi)
         if test $status -eq 0
             # git status --short automatically escapes the paths of most files for us so not going to bother trying to handle
             # the few edges cases of weird file names that should be extremely rare (e.g. "this;needs;escaping")


### PR DESCRIPTION
In multiple places we check if we're in a git repo like so:

   ```fish
   if not git rev-parse --git-dir >/dev/null 2>&1
       error
   else
       git do stuff | fzf
   end
   ```

   Instead do

   ```fish
   if not set -l gitDoStuff (git do stuff 2>/dev/null)
       error
   else
       printf '%s\n' $gitDoStuff | fzf
   end
   ```

This is much faster because running any git command checks for a git repo in the same amount of time. Thus we're saving on running a git command twice if it turns out you are in a git repo.

Broken out from #30