### PR TITLE
put $fish_key_bindings inside quotes

### DIFF
--- a/conf.d/fzf.fish
+++ b/conf.d/fzf.fish
@@ -9,7 +9,7 @@ if not set --query fzf_fish_custom_keybindings
     bind \e\cs '__fzf_search_git_status'
 
     # set up the same key bindings for insert mode if using fish_vi_key_bindings
-    if [ $fish_key_bindings = 'fish_vi_key_bindings' ]
+    if [ "$fish_key_bindings" = 'fish_vi_key_bindings' ]
         bind --mode insert \cf '__fzf_search_current_dir'
         bind --mode insert \cr '__fzf_search_history'
         bind --mode insert \cv '__fzf_search_shell_variables'


### PR DESCRIPTION
This commit fixes startup error messages of fzf.fish in case
$fish_key_bindings is not set.
If $fish_key_bindings is not set to a value, fzf.fish would generate the
following error messages on startup:
[: Missing argument at index 2

~/.config/fish/conf.d/fzf.fish (line 12):
    if [ $fish_key_bindings = 'fish_vi_key_bindings' ]
       ^
from sourcing file ~/.config/fish/conf.d/fzf.fish
	called on line 294 of file /usr/share/fish/config.fish
from sourcing file /usr/share/fish/config.fish
	called during startup