### PR TITLE
Always repaint in search_git_status

### DIFF
--- a/functions/__fzf_search_git_status.fish
+++ b/functions/__fzf_search_git_status.fish
@@ -23,7 +23,7 @@ function __fzf_search_git_status --description "Search the git status of the cur
                 commandline --insert $cleaned_path_padded
             end
         end
-
-        commandline --function repaint
     end
+
+    commandline --function repaint
 end


### PR DESCRIPTION
I mentioned this earlier and forgot. When running the `search_git_status` function, repaint should always be used (like in `search_git_log`) because something will always be printed.

Broken out from #30 