### PR TITLE
Stylistic and more idiomatic code

### DIFF
--- a/conf.d/fzf.fish
+++ b/conf.d/fzf.fish
@@ -9,7 +9,7 @@ if not set --query fzf_fish_custom_keybindings
     bind \e\cs '__fzf_search_git_status'
 
     # set up the same key bindings for insert mode if using fish_vi_key_bindings
-    if [ "$fish_key_bindings" = 'fish_vi_key_bindings' ]
+    if test "$fish_key_bindings" = 'fish_vi_key_bindings'
         bind --mode insert \cf '__fzf_search_current_dir'
         bind --mode insert \cr '__fzf_search_history'
         bind --mode insert \cv '__fzf_search_shell_variables'

--- a/functions/__fzf_search_current_dir.fish
+++ b/functions/__fzf_search_current_dir.fish
@@ -4,12 +4,12 @@ function __fzf_search_current_dir --description "Search the current directory us
     # See similar comment in __fzf_search_shell_variables.fish.
     set --local --export SHELL (command --search fish)
     set file_path_selected (
-        fd --hidden --follow --color=always --exclude=.git 2> /dev/null |
+        fd --hidden --follow --color=always --exclude=.git 2>/dev/null |
         fzf --ansi --preview='__fzf_preview_file {}'
     )
 
     if test $status -eq 0
-        commandline --insert (echo $file_path_selected | string escape)
+        commandline --insert (string escape "$file_path_selected")
     end
 
     commandline --function repaint


### PR DESCRIPTION
A few incredibly minor edits:

1. Use `test` instead of `[ ... ]`, in accordance with documentation and the rest of the code. https://github.com/fish-shell/fish-shell/issues/1850 says that use of the square brackets for test is highly discouraged.
2. Use `2>/dev/null` instead of `2> /dev/null`. This is preferred by `fish_indent`. I can demonstrate this if you wish.
3. Use `string escape "$blah"` instead of `echo $blah | string escape` 