### PR TITLE
Don't suggest reporting an issue for unknown file types in __fzf_preview_file

### DIFF
--- a/functions/__fzf_preview_file.fish
+++ b/functions/__fzf_preview_file.fish
@@ -23,6 +23,6 @@ function __fzf_preview_file --argument-names file_path --description "Prints a p
     else if test -p "$file_path"
         __fzf_report_file_type "$file_path" "named pipe"
     else
-        echo "Unexpected file symbol $file_type_char. Please open an issue at https://github.com/patrickf3139/fzf.fish." >&2
+        echo "Unknown file type." >&2
     end
 end


### PR DESCRIPTION
This was some remnant code we failed to remove when switching from `ls` to `test`. I have chosen to not direct people to open an issue with this repository because there isn't really anything we could do--we are using all available file `test`s already.